### PR TITLE
Update SQL statement that removes user for P-SQL

### DIFF
--- a/classes/feature/usersync/main.php
+++ b/classes/feature/usersync/main.php
@@ -555,7 +555,7 @@ class main {
                     // Check for synced user.
                     $sql = 'SELECT u.*
                               FROM {user} u
-                              JOIN {local_o365_objects} obj ON obj.type = "user" AND obj.moodleid = u.id
+                              JOIN {local_o365_objects} obj ON obj.type = \'user\' AND obj.moodleid = u.id
                               JOIN {auth_oidc_token} tok ON tok.username = u.username
                              WHERE u.username = ?
                                    AND u.mnethostid = ?

--- a/classes/rest/unified.php
+++ b/classes/rest/unified.php
@@ -1470,7 +1470,7 @@ class unified extends \local_o365\rest\o365api {
                        tok.oidcuniqid as userobjectid
                   FROM {auth_oidc_token} tok
                   JOIN {user} u ON u.username = tok.username
-                 WHERE tok.resource = ? AND u.id = ? AND u.deleted = "0"';
+                 WHERE tok.resource = ? AND u.id = ? AND u.deleted = 0';
         $params = ['https://graph.windows.net', $userid];
         $userobject = $DB->get_record_sql($sql, $params);
         if (empty($userobject)) {
@@ -1501,7 +1501,7 @@ class unified extends \local_o365\rest\o365api {
                        tok.oidcuniqid as userobjectid
                   FROM {auth_oidc_token} tok
                   JOIN {user} u ON u.username = tok.username
-                 WHERE tok.resource = ? AND u.id = ? AND u.deleted = "0"';
+                 WHERE tok.resource = ? AND u.id = ? AND u.deleted = 0';
         $params = ['https://graph.windows.net', $userid];
         $userobject = $DB->get_record_sql($sql, $params);
         if (empty($userobject)) {


### PR DESCRIPTION
Postgres treats double quoted strings as column names, so switch to single quotes which must be escaped. MySQL doesn't care either way.